### PR TITLE
fix: standalore radar profile

### DIFF
--- a/src/ui.rs
+++ b/src/ui.rs
@@ -45,7 +45,7 @@ const APP_MENU_QUICK_START: &Menu = &Menu {
         MenuItem {
             name: "CS2 Web Radar with KDMapper",
             action: MenuAction::Command(AppCommand::QuickStart {
-                enhancer: Enhancer::Cs2Overlay,
+                enhancer: Enhancer::Cs2StandaloneRadar,
             }),
         },
     ],


### PR DESCRIPTION
The quick-start profile selection was mapping CS2 Radar to CS2 overlay. This PR fixes it